### PR TITLE
Add benchmark_pub.py and benchmark_sub.cpp

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -56,4 +56,5 @@ RUN sudo apt-get update \
   && . /opt/ros/jazzy/setup.sh \
   && rosdep update \
   && rosdep install -i -y --from-path src \
+  --skip-keys=benchmark_msgs \
   && sudo rm -rf /var/lib/apt/lists/*

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -1,0 +1,77 @@
+## Benchmarking Flatros2 Performance
+
+This section describes a benchmarking setup to measure the latency of large messages using Flatros2 with Iceoryx2. The setup includes custom publisher and subscriber nodes with flexible CLI options and robust diagnostics, as well as an analysis script for results.
+
+### Components
+
+- **Publisher (Python, `benchmark_pub.py`):**
+    - Publishes messages of configurable sizes, either sweeping through a range or sending fixed sizes for a set duration.
+    - Supports CLI arguments:
+        - `--sizes`: Comma-separated list of message sizes in bytes (e.g., `--sizes 10,1000,10000`).
+        - `--mode`: `sweep` (vary sizes) or `fixed_size` (single size).
+        - `--duration`: Duration in seconds to send messages (for `fixed_size` mode).
+        - `--period`: Period in milliseconds between messages.
+        - Prints the current message size before publishing in `fixed_size` mode.
+
+- **Subscriber (C++, `benchmark_sub`):**
+    - Receives messages and logs latency to `latency_log.csv`.
+    - Supports CLI arguments:
+        - `--log`: Enable/disable CSV logging.
+        - `--debug`: Enable debug output.
+        - `--duration`/`-d`: Duration in seconds to run.
+        - Prints a clear warning at startup about how to kill the process (since Ctrl+C may not work; use `pkill` as below).
+
+- **Analyzer (Python, `analyze_latency.py`):**
+    - Reads and cleans the latency CSV file.
+    - Plots latency vs. message size and saves the figure as `latency_vs_size.png`.
+    - Prints mean, min, max latency for message size ranges.
+
+### Instructions
+
+#### 1. Run the Subscriber
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_iceoryx2_cxx
+./install/flatros2/lib/flatros2/benchmark_sub --duration 5 --log true --debug
+```
+
+> [!NOTE]
+> At startup, the subscriber prints a warning about how to kill the process. If Ctrl+C does not work, use the `pkill` command below.
+
+#### 2. Run the Publisher
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_iceoryx2_cxx
+python3 install/flatros2/lib/flatros2/benchmark_pub.py --mode fixed_size --sizes 10,1000,10000 --period 1000
+```
+
+You can also use `--mode fixed_size --duration 10` to send a fixed size for a set duration.
+
+#### 3. Kill Existing Iceoryx2 State (Recommended)
+
+```bash
+pkill -9 -f 'benchmark_pub|benchmark_sub|ros2'
+sudo rm -f /dev/shm/iox2_*
+sudo rm -rf /tmp/iceoryx2
+```
+
+The subscriber will log latency data to `latency_log.csv`.
+
+#### 4. Analyze Results
+
+Use the provided script to generate a plot and summary statistics:
+
+```bash
+python3 analyze_latency.py
+```
+
+This script:
+- Reads and cleans the latency CSV file
+- Plots latency vs. message size and saves the figure as `latency_vs_size.png`
+- Prints mean, min, max latency for message size ranges
+
+You can find the script in the root directory as `analyze_latency.py`.

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -100,7 +100,7 @@ To analyze CPU usage and bottlenecks during benchmarking, you can generate a CPU
 2. **Start the publisher in another terminal:**
 
         ```bash
-        python3 install/flatros2/lib/flatros2/benchmark_pub.py --duration 60 --period 50 --sizes 2000000
+        python3 install/flatros2/lib/flatros2/benchmark_pub.py --duration 60 --period 10 --sizes 2000000
         ```
 
 3. **Find the process IDs (PIDs) for both processes in a third terminal:**

--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ vcs import < /workspace/src/iceoryx.repos
 
 - For the ROS 2 core workspace, use the provided `ros2-core.repos` file:
 
-This step is optional! Is just to have the source code be able
-to instrument code and debug better.
+This next step is optional. It allows to have the source code available for instrumentation and debug.
 
 ```bash
 cd ~/ros2-core/src
@@ -151,81 +150,3 @@ You should see the real-time edge-detected video stream pop up in a separate win
 ## License
 
 This project is licensed under the Apache 2.0 License - see the [LICENSE](./LICENSE) file for details.
-
-## Benchmarking Flatros2 Performance
-
-This section describes a benchmarking setup to measure the latency of large messages using Flatros2 with Iceoryx2. The setup includes custom publisher and subscriber nodes with flexible CLI options and robust diagnostics, as well as an analysis script for results.
-
-### Components
-
-- **Publisher (Python, `benchmark_pub.py`):**
-    - Publishes messages of configurable sizes, either sweeping through a range or sending fixed sizes for a set duration.
-    - Supports CLI arguments:
-        - `--sizes`: Comma-separated list of message sizes in bytes (e.g., `--sizes 10,1000,10000`).
-        - `--mode`: `sweep` (vary sizes) or `fixed_size` (single size).
-        - `--duration`: Duration in seconds to send messages (for `fixed_size` mode).
-        - `--period`: Period in milliseconds between messages.
-        - Prints the current message size before publishing in `fixed_size` mode.
-
-- **Subscriber (C++, `benchmark_sub`):**
-    - Receives messages and logs latency to `latency_log.csv`.
-    - Supports CLI arguments:
-        - `--log`: Enable/disable CSV logging.
-        - `--debug`: Enable debug output.
-        - `--duration`/`-d`: Duration in seconds to run.
-        - Prints a clear warning at startup about how to kill the process (since Ctrl+C may not work; use `pkill` as below).
-
-- **Analyzer (Python, `analyze_latency.py`):**
-    - Reads and cleans the latency CSV file.
-    - Plots latency vs. message size and saves the figure as `latency_vs_size.png`.
-    - Prints mean, min, max latency for message size ranges.
-
-### Instructions
-
-#### 1. Run the Subscriber
-
-```bash
-source /opt/ros/jazzy/setup.bash
-source install/setup.bash
-export RMW_IMPLEMENTATION=rmw_iceoryx2_cxx
-./install/flatros2/lib/flatros2/benchmark_sub --duration 5 --log true --debug
-```
-
-> [!NOTE]
-> At startup, the subscriber prints a warning about how to kill the process. If Ctrl+C does not work, use the `pkill` command below.
-
-#### 2. Run the Publisher
-
-```bash
-source /opt/ros/jazzy/setup.bash
-source install/setup.bash
-export RMW_IMPLEMENTATION=rmw_iceoryx2_cxx
-python3 install/flatros2/lib/flatros2/benchmark_pub.py --mode fixed_size --sizes 10,1000,10000 --period 1000
-```
-
-You can also use `--mode fixed_size --duration 10` to send a fixed size for a set duration.
-
-#### 3. Kill Existing Iceoryx2 State (Recommended)
-
-```bash
-pkill -9 -f 'benchmark_pub|benchmark_sub|ros2'
-sudo rm -f /dev/shm/iox2_*
-sudo rm -rf /tmp/iceoryx2
-```
-
-The subscriber will log latency data to `latency_log.csv`.
-
-#### 4. Analyze Results
-
-Use the provided script to generate a plot and summary statistics:
-
-```bash
-python3 analyze_latency.py
-```
-
-This script:
-- Reads and cleans the latency CSV file
-- Plots latency vs. message size and saves the figure as `latency_vs_size.png`
-- Prints mean, min, max latency for message size ranges
-
-You can find the script in the root directory as `analyze_latency.py`.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ export RMW_IMPLEMENTATION=rmw_iceoryx2_cxx
 source /opt/ros/jazzy/setup.bash
 source install/setup.bash
 export RMW_IMPLEMENTATION=rmw_iceoryx2_cxx
-python3 install/flatros2/lib/flatros2/benchmark_pub.py --mode sweep --sizes 10,1000,10000 --period 1000
+python3 install/flatros2/lib/flatros2/benchmark_pub.py --mode fixed_size --sizes 10,1000,10000 --period 1000
 ```
 
 You can also use `--mode fixed_size --duration 10` to send a fixed size for a set duration.

--- a/analyze_latency.py
+++ b/analyze_latency.py
@@ -1,9 +1,16 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
+import argparse
+
+
+# Parse arguments
+parser = argparse.ArgumentParser(description="Analyze latency log CSV and plot results.")
+parser.add_argument('-p', '--path', type=str, default='latency_log.csv', help='Path to latency log CSV file (default: latency_log.csv)')
+args = parser.parse_args()
 
 # Read the CSV, skipping non-data lines
-with open('latency_log.csv', 'r') as f:
+with open(args.path, 'r') as f:
     lines = f.readlines()
 
 # Find the header line
@@ -14,15 +21,24 @@ for i, line in enumerate(lines):
 else:
     raise ValueError('No header found in latency_log.csv')
 
+
 # Read the data into a DataFrame
 from io import StringIO
 data_str = ''.join(lines[header_idx:])
 df = pd.read_csv(StringIO(data_str))
+# Ensure size_bytes is numeric
+df['size_bytes'] = pd.to_numeric(df['size_bytes'], errors='coerce')
+df = df.dropna(subset=['size_bytes'])
+df['size_bytes'] = df['size_bytes'].astype(int)
+
+
+# Convert size to kilobytes for plotting and stats
+df['size_kb'] = df['size_bytes'] / 1024
 
 # Plot
 plt.figure(figsize=(10,6))
-plt.plot(df['size_bytes'], df['latency_ms'], marker='.', linestyle='-', alpha=0.7)
-plt.xlabel('Message Size (bytes)')
+plt.plot(df['size_kb'], df['latency_ms'], marker='.', linestyle='-', alpha=0.7)
+plt.xlabel('Message Size (kB)')
 plt.ylabel('Latency (ms)')
 plt.title('Message Latency vs. Size')
 plt.grid(True)
@@ -31,9 +47,11 @@ plt.savefig('latency_vs_size.png')
 plt.show()
 
 # Print summary statistics
-print('Latency statistics by message size range:')
-for start in range(0, df['size_bytes'].max(), 100000):
-    end = start + 100000
-    subset = df[(df['size_bytes'] >= start) & (df['size_bytes'] < end)]
+print('Latency statistics by message size range (kB):')
+step_kb = 100
+for start_kb in range(0, int(df['size_kb'].max()) + step_kb, step_kb):
+    end_kb = start_kb + step_kb
+    subset = df[(df['size_kb'] >= start_kb) & (df['size_kb'] < end_kb)]
     if not subset.empty:
-        print(f"{start} - {end} bytes: count={len(subset)}, mean={subset['latency_ms'].mean():.3f} ms, min={subset['latency_ms'].min():.3f} ms, max={subset['latency_ms'].max():.3f} ms")
+        print(f"{start_kb} - {end_kb} kB: count={len(subset)}, mean={subset['latency_ms'].mean():.3f} ms, min={subset['latency_ms'].min():.3f} ms, max={subset['latency_ms'].max():.3f} ms")
+

--- a/analyze_latency.py
+++ b/analyze_latency.py
@@ -1,0 +1,39 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+
+# Read the CSV, skipping non-data lines
+with open('latency_log.csv', 'r') as f:
+    lines = f.readlines()
+
+# Find the header line
+for i, line in enumerate(lines):
+    if line.strip().startswith('size_bytes'):
+        header_idx = i
+        break
+else:
+    raise ValueError('No header found in latency_log.csv')
+
+# Read the data into a DataFrame
+from io import StringIO
+data_str = ''.join(lines[header_idx:])
+df = pd.read_csv(StringIO(data_str))
+
+# Plot
+plt.figure(figsize=(10,6))
+plt.plot(df['size_bytes'], df['latency_ms'], marker='.', linestyle='-', alpha=0.7)
+plt.xlabel('Message Size (bytes)')
+plt.ylabel('Latency (ms)')
+plt.title('Message Latency vs. Size')
+plt.grid(True)
+plt.tight_layout()
+plt.savefig('latency_vs_size.png')
+plt.show()
+
+# Print summary statistics
+print('Latency statistics by message size range:')
+for start in range(0, df['size_bytes'].max(), 100000):
+    end = start + 100000
+    subset = df[(df['size_bytes'] >= start) & (df['size_bytes'] < end)]
+    if not subset.empty:
+        print(f"{start} - {end} bytes: count={len(subset)}, mean={subset['latency_ms'].mean():.3f} ms, min={subset['latency_ms'].min():.3f} ms, max={subset['latency_ms'].max():.3f} ms")

--- a/benchmark_msgs/CMakeLists.txt
+++ b/benchmark_msgs/CMakeLists.txt
@@ -4,13 +4,26 @@ project(benchmark_msgs)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(rosidl_typesupport_c REQUIRED)
+find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
+# Generate interfaces
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/BenchmarkData.msg"
+  "msg/Stamped10B.msg"
+  "msg/Stamped100KB.msg"
+  "msg/Stamped1MB.msg"
+  "msg/Stamped2MB.msg"
+  "msg/Stamped4MB.msg"
   DEPENDENCIES std_msgs
-  # GENERATE_TYPESUPPORT "rosidl_typesupport_c"
 )
 
-ament_export_dependencies(rosidl_default_runtime std_msgs)
+# Export necessary dependencies
+ament_export_dependencies(
+  rosidl_default_runtime
+  rosidl_typesupport_c
+  rosidl_typesupport_cpp
+  std_msgs
+)
+
 ament_package()

--- a/benchmark_msgs/CMakeLists.txt
+++ b/benchmark_msgs/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.5)
+project(benchmark_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_typesupport_c REQUIRED)
+find_package(std_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/BenchmarkData.msg"
+  DEPENDENCIES std_msgs
+  # GENERATE_TYPESUPPORT "rosidl_typesupport_c"
+)
+
+ament_export_dependencies(rosidl_default_runtime std_msgs)
+ament_package()

--- a/benchmark_msgs/msg/BenchmarkData.msg
+++ b/benchmark_msgs/msg/BenchmarkData.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+uint8[] data
+

--- a/benchmark_msgs/msg/Stamped100KB.msg
+++ b/benchmark_msgs/msg/Stamped100KB.msg
@@ -1,0 +1,3 @@
+# This message contains a header and a fixed-size array of 100,000 bytes
+std_msgs/Header header
+uint8[100000] data

--- a/benchmark_msgs/msg/Stamped10B.msg
+++ b/benchmark_msgs/msg/Stamped10B.msg
@@ -1,0 +1,3 @@
+# This message contains a header and a fixed-size array of 10 bytes
+std_msgs/Header header
+uint8[10] data

--- a/benchmark_msgs/msg/Stamped1MB.msg
+++ b/benchmark_msgs/msg/Stamped1MB.msg
@@ -1,0 +1,3 @@
+# This message contains a header and a fixed-size array of 1,000,000 bytes
+std_msgs/Header header
+uint8[1000000] data

--- a/benchmark_msgs/msg/Stamped2MB.msg
+++ b/benchmark_msgs/msg/Stamped2MB.msg
@@ -1,0 +1,3 @@
+# This message contains a header and a fixed-size array of 2,000,000 bytes
+std_msgs/Header header
+uint8[2000000] data

--- a/benchmark_msgs/msg/Stamped4MB.msg
+++ b/benchmark_msgs/msg/Stamped4MB.msg
@@ -1,0 +1,3 @@
+# This message contains a header and a fixed-size array of 4,000,000 bytes
+std_msgs/Header header
+uint8[4000000] data

--- a/benchmark_msgs/package.xml
+++ b/benchmark_msgs/package.xml
@@ -1,0 +1,21 @@
+<package format="3">
+  <name>benchmark_msgs</name>
+  <version>0.0.1</version>
+  <description>Benchmark message for flatros2 tests</description>
+
+  <maintainer email="you@example.com">Your Name</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>std_msgs</build_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <build_depend>rosidl_typesupport_c</build_depend>
+  <exec_depend>rosidl_typesupport_c</exec_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+</package>

--- a/benchmark_msgs/package.xml
+++ b/benchmark_msgs/package.xml
@@ -1,20 +1,26 @@
 <package format="3">
   <name>benchmark_msgs</name>
   <version>0.0.1</version>
-  <description>Benchmark message for flatros2 tests</description>
+  <description>Benchmark messages for flatros2 tests</description>
 
   <maintainer email="you@example.com">Your Name</maintainer>
   <license>Apache-2.0</license>
 
+  <!-- Build tools -->
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <buildtool_export_depend>rosidl_default_generators</buildtool_export_depend>
 
+  <!-- Dependencies -->
   <build_depend>std_msgs</build_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <build_depend>rosidl_typesupport_c</build_depend>
   <exec_depend>rosidl_typesupport_c</exec_depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>rosidl_typesupport_cpp</build_depend>
+  <exec_depend>rosidl_typesupport_cpp</exec_depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/flatros2/CMakeLists.txt
+++ b/flatros2/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(ament_cmake_python REQUIRED)
 
 find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(benchmark_msgs REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)

--- a/flatros2/examples/CMakeLists.txt
+++ b/flatros2/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(benchmark_msgs REQUIRED)
 
 add_executable(edge_detector_node edge_detector_node.cpp)
 target_link_libraries(edge_detector_node PRIVATE
-    ${PROJECT_NAME} ${sensor_msgs_TARGETS} ${std_msgs_TARGETS} 
+    ${PROJECT_NAME} ${sensor_msgs_TARGETS} ${std_msgs_TARGETS}
     cv_bridge::cv_bridge opencv_core opencv_objdetect rclcpp::rclcpp)
 
 install(
@@ -35,5 +35,37 @@ target_include_directories(benchmark_sub PUBLIC
 
 install(
   TARGETS benchmark_sub
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(benchmark_pub_fixed_size benchmark_pub_fixed_size.cpp)
+target_link_libraries(benchmark_pub_fixed_size
+  ${PROJECT_NAME}
+)
+ament_target_dependencies(benchmark_pub_fixed_size
+  rclcpp
+  benchmark_msgs
+)
+target_include_directories(benchmark_pub_fixed_size PUBLIC
+  $<BUILD_INTERFACE:${benchmark_msgs_DIR}/../../../include>
+)
+install(
+  TARGETS benchmark_pub_fixed_size
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(benchmark_sub_fixed_size benchmark_sub_fixed_size.cpp)
+target_link_libraries(benchmark_sub_fixed_size
+  ${PROJECT_NAME}
+)
+ament_target_dependencies(benchmark_sub_fixed_size
+  rclcpp
+  benchmark_msgs
+)
+target_include_directories(benchmark_sub_fixed_size PUBLIC
+  $<BUILD_INTERFACE:${benchmark_msgs_DIR}/../../../include>
+)
+install(
+  TARGETS benchmark_sub_fixed_size
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/flatros2/examples/CMakeLists.txt
+++ b/flatros2/examples/CMakeLists.txt
@@ -1,16 +1,39 @@
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
+find_package(benchmark_msgs REQUIRED)
 
-add_executable(face_detector_node face_detector_node.cpp)
-target_link_libraries(face_detector_node PRIVATE 
+add_executable(edge_detector_node edge_detector_node.cpp)
+target_link_libraries(edge_detector_node PRIVATE
     ${PROJECT_NAME} ${sensor_msgs_TARGETS} ${std_msgs_TARGETS} 
     cv_bridge::cv_bridge opencv_core opencv_objdetect rclcpp::rclcpp)
 
 install(
-  TARGETS face_detector_node
+  TARGETS edge_detector_node
   DESTINATION lib/${PROJECT_NAME})
 
 install(
-  PROGRAMS image_capture_node.py image_viewer_node.py
-  DESTINATION lib/${PROJECT_NAME})
+  PROGRAMS
+    image_capture_node.py
+    image_viewer_node.py
+    benchmark_pub.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(benchmark_sub benchmark_sub.cpp)
+target_link_libraries(benchmark_sub
+  ${PROJECT_NAME}
+)
+ament_target_dependencies(benchmark_sub
+  rclcpp
+  benchmark_msgs
+)
+
+target_include_directories(benchmark_sub PUBLIC
+  $<BUILD_INTERFACE:${benchmark_msgs_DIR}/../../../include>
+)
+
+install(
+  TARGETS benchmark_sub
+  DESTINATION lib/${PROJECT_NAME}
+)

--- a/flatros2/examples/benchmark_pub.py
+++ b/flatros2/examples/benchmark_pub.py
@@ -47,7 +47,7 @@ class BenchmarkPublisher(Node):
             self.sizes = generate_sizes_linear(sweep_start, sweep_stop, sweep_step)
             self.index = 0
             self.publisher = self.make_flat_publisher(self.sizes[self.index])
-            self.timer = self.create_timer(0.01, self.sweep_send)
+            self.timer = self.create_timer(self.period_ms / 1000.0, self.sweep_send)
         else:
             # Fixed size mode: repeatedly send a fixed size
             self.sizes = sizes if sizes is not None else SIZES
@@ -55,7 +55,7 @@ class BenchmarkPublisher(Node):
             self.start_time = self.get_clock().now().seconds_nanoseconds()[0]
             self.publisher = self.make_flat_publisher(self.sizes[self.index])
             print(f"{self.CYAN}🔁 Now sending {self.YELLOW}{self.sizes[self.index]}{self.RESET} bytes")
-            self.timer = self.create_timer(0.01, self.fixed_size_send)
+            self.timer = self.create_timer(self.period_ms / 1000.0, self.fixed_size_send)
 
     def make_flat_publisher(self, size):
         """Create a FlatPublisher for a given message size."""
@@ -81,12 +81,10 @@ class BenchmarkPublisher(Node):
         now = self.get_clock().now().to_msg()
         msg.header.stamp.sec = now.sec
         msg.header.stamp.nanosec = now.nanosec
-        msg.data[:] = np.random.randint(0, 255, self.sizes[self.index], dtype=np.uint8)
         t0 = time.perf_counter()
         self.publisher.publish_loaned_message(msg)
         t1 = time.perf_counter()
         # print(f"{self.GREEN}Published {self.sizes[self.index]} bytes in {self.YELLOW}{1e3*(t1 - t0):.2f}{self.RESET} ms")
-        time.sleep(self.period_ms / 1000.0)
 
     def sweep_send(self):
         """Send one message for each size in the sweep list."""
@@ -106,7 +104,6 @@ class BenchmarkPublisher(Node):
         t1 = time.perf_counter()
         # print(f"{self.GREEN}Published {size} bytes in {self.YELLOW}{1e3*(t1 - t0):.2f}{self.RESET} ms")
         self.index += 1
-        time.sleep(self.period_ms / 1000.0)
 
 def main():
     """

--- a/flatros2/examples/benchmark_pub.py
+++ b/flatros2/examples/benchmark_pub.py
@@ -15,8 +15,6 @@ import argparse
 # SIZES = [10, 100_000, 1_000_000, 4_000_000]  # in bytes
 SIZES = [1_000_000]  # in bytes
 
-# Duration for duration mode (in seconds)
-DURATION = 10  # seconds
 
 def generate_sizes_linear(start, stop, step=1):
     """Generate a list of sizes from start to stop with a given step."""
@@ -25,7 +23,7 @@ def generate_sizes_linear(start, stop, step=1):
 class BenchmarkPublisher(Node):
     """
     ROS 2 node for publishing benchmark messages of varying sizes.
-    Publishes messages in either duration or sweep mode.
+    Publishes messages in either fixed_size or sweep mode.
     """
     # ANSI color codes for consistent use
     BOLD = '\033[1m'
@@ -35,9 +33,11 @@ class BenchmarkPublisher(Node):
     RED = '\033[31m'
     RESET = '\033[0m'
 
-    def __init__(self, mode="duration"):
+    def __init__(self, mode="fixed_size", duration=10, sizes=None, period_ms=1000):
         super().__init__('benchmark_publisher', start_parameter_services=False, enable_rosout=False, enable_logger_service=False)
         self.mode = mode
+        self.duration = duration
+        self.period_ms = period_ms
         if mode == "sweep":
             # Sweep mode: test a range of message sizes
             sweep_start = 1
@@ -49,22 +49,23 @@ class BenchmarkPublisher(Node):
             self.publisher = self.make_flat_publisher(self.sizes[self.index])
             self.timer = self.create_timer(0.01, self.sweep_send)
         else:
-            # Duration mode: repeatedly send a fixed size
-            self.sizes = SIZES
+            # Fixed size mode: repeatedly send a fixed size
+            self.sizes = sizes if sizes is not None else SIZES
             self.index = 0
             self.start_time = self.get_clock().now().seconds_nanoseconds()[0]
             self.publisher = self.make_flat_publisher(self.sizes[self.index])
-            self.timer = self.create_timer(0.01, self.duration_send)
+            print(f"{self.CYAN}🔁 Now sending {self.YELLOW}{self.sizes[self.index]}{self.RESET} bytes")
+            self.timer = self.create_timer(0.01, self.fixed_size_send)
 
     def make_flat_publisher(self, size):
         """Create a FlatPublisher for a given message size."""
         msg = BenchmarkData(header=Header(), data=np.zeros(size, dtype=np.uint8))
         return FlatPublisher(self, Flat(msg), 'benchmark_topic', 10)
 
-    def duration_send(self):
+    def fixed_size_send(self):
         """Send messages of a fixed size for a set duration."""
         now_sec = self.get_clock().now().seconds_nanoseconds()[0]
-        if now_sec - self.start_time >= DURATION:
+        if now_sec - self.start_time >= self.duration:
             self.index += 1
             if self.index >= len(self.sizes):
                 self.get_logger().info(f"{self.GREEN}{self.BOLD}✅ All sizes sent.{self.RESET}")
@@ -85,6 +86,7 @@ class BenchmarkPublisher(Node):
         self.publisher.publish_loaned_message(msg)
         t1 = time.perf_counter()
         # print(f"{self.GREEN}Published {self.sizes[self.index]} bytes in {self.YELLOW}{1e3*(t1 - t0):.2f}{self.RESET} ms")
+        time.sleep(self.period_ms / 1000.0)
 
     def sweep_send(self):
         """Send one message for each size in the sweep list."""
@@ -104,6 +106,7 @@ class BenchmarkPublisher(Node):
         t1 = time.perf_counter()
         # print(f"{self.GREEN}Published {size} bytes in {self.YELLOW}{1e3*(t1 - t0):.2f}{self.RESET} ms")
         self.index += 1
+        time.sleep(self.period_ms / 1000.0)
 
 def main():
     """
@@ -122,25 +125,66 @@ def main():
     CYAN = '\033[36m'
     RESET = '\033[0m'
     parser = argparse.ArgumentParser(
-        description=f'{BOLD}{GREEN}Benchmark Publisher{RESET}',
+        description=f'{BOLD}{GREEN}Benchmark Publisher{RESET}\n\n'
+                    f'{CYAN}Publishes messages of varying sizes to benchmark performance.\n{RESET}',
         epilog=(
-            f'{YELLOW}Example:{RESET} python3 benchmark_pub.py --mode duration\n'
-            f'{CYAN}This program publishes messages of varying sizes to benchmark performance.\n'
-            f'Use {YELLOW}--mode{RESET} to select between {GREEN}sweep{RESET} (default) or {GREEN}duration{RESET} mode.\n'
-            f'{YELLOW}Sweep mode:{RESET} publishes messages from 1 to 2000000 bytes with a step of 20000.\n'
-            f'{YELLOW}Note:{RESET} In another terminal, run the {GREEN}subscriber{RESET}:\n'
-            f'  {CYAN}./install/flatros2/lib/flatros2/benchmark_sub --duration 30{RESET}\n'
+            f'{BOLD}{YELLOW}Usage Examples:{RESET}\n'
+            f'  {CYAN}python3 benchmark_pub.py --mode sweep{RESET}         {YELLOW}# Sweep through many sizes{RESET}\n'
+            f'  {CYAN}python3 benchmark_pub.py --duration 10{RESET}        {YELLOW}# Fixed size(s), 10s each{RESET}\n'
+            f'\n'
+            f'{BOLD}{YELLOW}Options:{RESET}\n'
+            f'  {GREEN}--mode sweep|fixed_size{RESET}   Sweep (default) or fixed-size mode.\n'
+            f'  {GREEN}--duration N{RESET}            Duration (seconds) for each size in fixed-size mode. Implies --mode fixed_size.\n'
+            f'\n'
+            f'{BOLD}{YELLOW}Sweep mode:{RESET}\n'
+            f'  Publishes messages from 1 to 2,000,000 bytes with a step of 20,000.\n'
+            f'{BOLD}{YELLOW}Fixed size mode:{RESET}\n'
+            f'  Publishes each size for the specified duration (default: 10s per size).\n'
+            f'\n'
+            f'{BOLD}{YELLOW}Subscriber:{RESET}\n'
+            f'  In another terminal, run the subscriber to receive and log messages:\n'
+            f'    {CYAN}./install/flatros2/lib/flatros2/benchmark_sub --duration 30{RESET}\n'
+            f'\n'
+            f'{BOLD}{YELLOW}Analysis:{RESET}\n'
+            f'  Analyze results with: {CYAN}python3 /workspace/analyze_latency.py{RESET}\n'
         )
     )
-    parser.add_argument('--mode', choices=['duration', 'sweep'], default='sweep',
-                        help=f'{GREEN}sweep{RESET} (default) or {GREEN}duration{RESET}')
+    parser.add_argument('--mode', choices=['fixed_size', 'sweep'], default='sweep',
+                        help=f'{GREEN}sweep{RESET} (default) or {GREEN}fixed_size{RESET}')
+    parser.add_argument('--sizes', type=str, default=None,
+                        help=f'{GREEN}Comma-separated list of message sizes (bytes) for fixed_size mode. E.g. --sizes 10,1000,100000{RESET}')
+    parser.add_argument('--duration', type=int, default=None,
+                        help=f'{GREEN}Duration in seconds to publish each message size in fixed_size mode. If set, mode is forced to fixed_size. (default: None){RESET}')
+    parser.add_argument('--period', type=int, default=1000,
+                        help=f'{GREEN}Period in milliseconds between publishes (applies to both modes, default: 1000 ms){RESET}')
     import sys
     args = parser.parse_args()
+    # If --duration or --sizes is provided, force mode to 'fixed_size'
+    mode = args.mode
+    duration = args.duration
+    sizes = None
+    period_ms = args.period
+    if args.sizes is not None:
+        try:
+            sizes = [int(s) for s in args.sizes.split(',') if s.strip()]
+            if not sizes:
+                raise ValueError
+        except Exception:
+            print(f'{BOLD}Error:{RESET} --sizes must be a comma-separated list of positive integers.')
+            sys.exit(1)
+        mode = 'fixed_size'
+    if duration is not None:
+        mode = 'fixed_size'
+        if duration <= 0:
+            print(f'{BOLD}Error:{RESET} --duration must be a positive integer.')
+            sys.exit(1)
+    else:
+        duration = 10  # fallback default
     if len(sys.argv) == 1:
         print(f'{YELLOW}No arguments passed. Defaulting to sweep mode.{RESET}')
     rclpy.init()
     try:
-        rclpy.spin(BenchmarkPublisher(mode=args.mode))
+        rclpy.spin(BenchmarkPublisher(mode=mode, duration=duration, sizes=sizes, period_ms=period_ms))
     except KeyboardInterrupt:
         print(f"{YELLOW}Interrupted by user. Exiting...{RESET}")
     finally:
@@ -155,7 +199,7 @@ if __name__ == '__main__':
     RESET = '\033[0m'
     print(f'{BOLD}{GREEN}Starting Benchmark Publisher...{RESET}')
     print(f'{CYAN}This program benchmarks the publishing performance by sending messages of varying sizes.{RESET}')
-    print(f'Use the {YELLOW}"--mode"{RESET} argument to select between {GREEN}"duration"{RESET} and {GREEN}"sweep"{RESET} modes.')
+    print(f'Use the {YELLOW}"--mode"{RESET} argument to select between {GREEN}"fixed_size"{RESET} and {GREEN}"sweep"{RESET} modes.')
     print(f'{YELLOW}Note:{RESET} In another terminal, run the {GREEN}subscriber{RESET} to receive and log the messages:')
     print(f'  {CYAN}./install/flatros2/lib/flatros2/benchmark_sub --duration 30{RESET}')
     print(f'{YELLOW}Tip:{RESET} You can add {CYAN}-h{RESET} for help or change the duration as needed.')

--- a/flatros2/examples/benchmark_pub.py
+++ b/flatros2/examples/benchmark_pub.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+# Imports for time, ROS 2, message types, and numpy
+import time
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Header
+from benchmark_msgs.msg import BenchmarkData
+from flatros2 import Flat
+from flatros2.publisher import FlatPublisher
+import numpy as np
+import argparse
+
+# Default message sizes for benchmarking (in bytes)
+# SIZES = [10, 100_000, 1_000_000, 4_000_000]  # in bytes
+SIZES = [1_000_000]  # in bytes
+
+# Duration for duration mode (in seconds)
+DURATION = 10  # seconds
+
+def generate_sizes_linear(start, stop, step=1):
+    """Generate a list of sizes from start to stop with a given step."""
+    return list(range(start, stop + 1, step))
+
+class BenchmarkPublisher(Node):
+    """
+    ROS 2 node for publishing benchmark messages of varying sizes.
+    Publishes messages in either duration or sweep mode.
+    """
+    # ANSI color codes for consistent use
+    BOLD = '\033[1m'
+    GREEN = '\033[32m'
+    YELLOW = '\033[33m'
+    CYAN = '\033[36m'
+    RED = '\033[31m'
+    RESET = '\033[0m'
+
+    def __init__(self, mode="duration"):
+        super().__init__('benchmark_publisher', start_parameter_services=False, enable_rosout=False, enable_logger_service=False)
+        self.mode = mode
+        if mode == "sweep":
+            # Sweep mode: test a range of message sizes
+            sweep_start = 1
+            sweep_stop = 2_000_000
+            sweep_step = 20000
+            print(f"{self.CYAN}{self.BOLD}Sweep mode:{self.RESET} going to publish messages from {self.YELLOW}{sweep_start}{self.RESET} to {self.YELLOW}{sweep_stop}{self.RESET} bytes with a step of {self.YELLOW}{sweep_step}{self.RESET}.")
+            self.sizes = generate_sizes_linear(sweep_start, sweep_stop, sweep_step)
+            self.index = 0
+            self.publisher = self.make_flat_publisher(self.sizes[self.index])
+            self.timer = self.create_timer(0.01, self.sweep_send)
+        else:
+            # Duration mode: repeatedly send a fixed size
+            self.sizes = SIZES
+            self.index = 0
+            self.start_time = self.get_clock().now().seconds_nanoseconds()[0]
+            self.publisher = self.make_flat_publisher(self.sizes[self.index])
+            self.timer = self.create_timer(0.01, self.duration_send)
+
+    def make_flat_publisher(self, size):
+        """Create a FlatPublisher for a given message size."""
+        msg = BenchmarkData(header=Header(), data=np.zeros(size, dtype=np.uint8))
+        return FlatPublisher(self, Flat(msg), 'benchmark_topic', 10)
+
+    def duration_send(self):
+        """Send messages of a fixed size for a set duration."""
+        now_sec = self.get_clock().now().seconds_nanoseconds()[0]
+        if now_sec - self.start_time >= DURATION:
+            self.index += 1
+            if self.index >= len(self.sizes):
+                self.get_logger().info(f"{self.GREEN}{self.BOLD}✅ All sizes sent.{self.RESET}")
+                rclpy.shutdown()
+                return
+            self.current_size = self.sizes[self.index]
+            self.publisher = self.make_flat_publisher(self.current_size)
+            self.start_time = now_sec
+            self.get_logger().info(f"{self.CYAN}🔁 Now sending {self.YELLOW}{self.current_size}{self.RESET} bytes")
+            return
+
+        msg = self.publisher.borrow_loaned_message()
+        now = self.get_clock().now().to_msg()
+        msg.header.stamp.sec = now.sec
+        msg.header.stamp.nanosec = now.nanosec
+        msg.data[:] = np.random.randint(0, 255, self.sizes[self.index], dtype=np.uint8)
+        t0 = time.perf_counter()
+        self.publisher.publish_loaned_message(msg)
+        t1 = time.perf_counter()
+        # print(f"{self.GREEN}Published {self.sizes[self.index]} bytes in {self.YELLOW}{1e3*(t1 - t0):.2f}{self.RESET} ms")
+
+    def sweep_send(self):
+        """Send one message for each size in the sweep list."""
+        if self.index >= len(self.sizes):
+            self.get_logger().info(f"{self.GREEN}{self.BOLD}✅ Sweep complete.{self.RESET}")
+            rclpy.shutdown()
+            return
+        size = self.sizes[self.index]
+        self.publisher = self.make_flat_publisher(size)
+        msg = self.publisher.borrow_loaned_message()
+        now = self.get_clock().now().to_msg()
+        msg.header.stamp.sec = now.sec
+        msg.header.stamp.nanosec = now.nanosec
+        msg.data[:] = np.random.randint(0, 255, size, dtype=np.uint8)
+        t0 = time.perf_counter()
+        self.publisher.publish_loaned_message(msg)
+        t1 = time.perf_counter()
+        # print(f"{self.GREEN}Published {size} bytes in {self.YELLOW}{1e3*(t1 - t0):.2f}{self.RESET} ms")
+        self.index += 1
+
+def main():
+    """
+    Main function for the benchmark publisher script.
+
+    Parses command-line arguments and starts the publisher node.
+
+    Args:
+        --mode: Specifies the publishing mode ('duration' or 'sweep').
+        --help: Displays instructions on how to run the script.
+    """
+    # ANSI color codes (for use outside the class)
+    BOLD = '\033[1m'
+    GREEN = '\033[32m'
+    YELLOW = '\033[33m'
+    CYAN = '\033[36m'
+    RESET = '\033[0m'
+    parser = argparse.ArgumentParser(
+        description=f'{BOLD}{GREEN}Benchmark Publisher{RESET}',
+        epilog=(
+            f'{YELLOW}Example:{RESET} python3 benchmark_pub.py --mode duration\n'
+            f'{CYAN}This program publishes messages of varying sizes to benchmark performance.\n'
+            f'Use {YELLOW}--mode{RESET} to select between {GREEN}sweep{RESET} (default) or {GREEN}duration{RESET} mode.\n'
+            f'{YELLOW}Sweep mode:{RESET} publishes messages from 1 to 2000000 bytes with a step of 20000.\n'
+            f'{YELLOW}Note:{RESET} In another terminal, run the {GREEN}subscriber{RESET}:\n'
+            f'  {CYAN}./install/flatros2/lib/flatros2/benchmark_sub --duration 30{RESET}\n'
+        )
+    )
+    parser.add_argument('--mode', choices=['duration', 'sweep'], default='sweep',
+                        help=f'{GREEN}sweep{RESET} (default) or {GREEN}duration{RESET}')
+    import sys
+    args = parser.parse_args()
+    if len(sys.argv) == 1:
+        print(f'{YELLOW}No arguments passed. Defaulting to sweep mode.{RESET}')
+    rclpy.init()
+    try:
+        rclpy.spin(BenchmarkPublisher(mode=args.mode))
+    except KeyboardInterrupt:
+        print(f"{YELLOW}Interrupted by user. Exiting...{RESET}")
+    finally:
+        rclpy.try_shutdown()
+
+if __name__ == '__main__':
+    # ANSI color codes (for use outside the class)
+    BOLD = '\033[1m'
+    GREEN = '\033[32m'
+    YELLOW = '\033[33m'
+    CYAN = '\033[36m'
+    RESET = '\033[0m'
+    print(f'{BOLD}{GREEN}Starting Benchmark Publisher...{RESET}')
+    print(f'{CYAN}This program benchmarks the publishing performance by sending messages of varying sizes.{RESET}')
+    print(f'Use the {YELLOW}"--mode"{RESET} argument to select between {GREEN}"duration"{RESET} and {GREEN}"sweep"{RESET} modes.')
+    print(f'{YELLOW}Note:{RESET} In another terminal, run the {GREEN}subscriber{RESET} to receive and log the messages:')
+    print(f'  {CYAN}./install/flatros2/lib/flatros2/benchmark_sub --duration 30{RESET}')
+    print(f'{YELLOW}Tip:{RESET} You can add {CYAN}-h{RESET} for help or change the duration as needed.')
+    main()

--- a/flatros2/examples/benchmark_pub_fixed_size.cpp
+++ b/flatros2/examples/benchmark_pub_fixed_size.cpp
@@ -1,0 +1,119 @@
+// benchmark_pub_fixed_size.cpp
+// Publishes fixed-size messages for benchmarking, similar to benchmark_pub.py
+// Usage: ros2 run <package> benchmark_pub_fixed_size --sizes 10 100kb 1mb 2mb 4mb --rate <hz>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/header.hpp>
+#include "benchmark_msgs/msg/stamped10_b.hpp"
+#include "benchmark_msgs/msg/stamped100_kb.hpp"
+#include "benchmark_msgs/msg/stamped1_mb.hpp"
+#include "benchmark_msgs/msg/stamped2_mb.hpp"
+#include "benchmark_msgs/msg/stamped4_mb.hpp"
+
+using namespace std::chrono_literals;
+
+struct SizeInfo {
+  std::string name;
+  size_t size_bytes;
+};
+
+const std::unordered_map<std::string, SizeInfo> size_map = {
+  {"10", {"Stamped10B", 10}},
+  {"100kb", {"Stamped100KB", 100 * 1024}},
+  {"1mb", {"Stamped1MB", 1024 * 1024}},
+  {"2mb", {"Stamped2MB", 2 * 1024 * 1024}},
+  {"4mb", {"Stamped4MB", 4 * 1024 * 1024}},
+};
+
+class BenchmarkPubNode : public rclcpp::Node {
+public:
+  BenchmarkPubNode(const std::vector<std::string>& sizes, int period_ms)
+    : Node("benchmark_pub_fixed_size"), sizes_(sizes), period_ms_(period_ms) {
+    using namespace std::placeholders;
+    for (const auto& size : sizes_) {
+      if (size == "10") {
+        pub10_ = this->create_publisher<benchmark_msgs::msg::Stamped10B>("benchmark/fixed/10", 10);
+      } else if (size == "100kb") {
+        pub100kb_ = this->create_publisher<benchmark_msgs::msg::Stamped100KB>("benchmark/fixed/100kb", 10);
+      } else if (size == "1mb") {
+        pub1mb_ = this->create_publisher<benchmark_msgs::msg::Stamped1MB>("benchmark/fixed/1mb", 10);
+      } else if (size == "2mb") {
+        pub2mb_ = this->create_publisher<benchmark_msgs::msg::Stamped2MB>("benchmark/fixed/2mb", 10);
+      } else if (size == "4mb") {
+        pub4mb_ = this->create_publisher<benchmark_msgs::msg::Stamped4MB>("benchmark/fixed/4mb", 10);
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "Unknown size: %s", size.c_str());
+      }
+    }
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(period_ms_),
+      std::bind(&BenchmarkPubNode::timer_callback, this));
+  }
+
+private:
+  void timer_callback() {
+    // No initialization, always use loaned messages (assume support)
+    for (const auto& size : sizes_) {
+      if (size == "10" && pub10_) {
+        std::cout << "Publishing size: 10 bytes" << std::endl;
+        auto loaned = pub10_->borrow_loaned_message();
+        pub10_->publish(std::move(loaned));
+      } else if (size == "100kb" && pub100kb_) {
+        std::cout << "Publishing size: 100 KB" << std::endl;
+        auto loaned = pub100kb_->borrow_loaned_message();
+        pub100kb_->publish(std::move(loaned));
+      } else if (size == "1mb" && pub1mb_) {
+        std::cout << "Publishing size: 1 MB" << std::endl;
+        auto loaned = pub1mb_->borrow_loaned_message();
+        pub1mb_->publish(std::move(loaned));
+      } else if (size == "2mb" && pub2mb_) {
+        std::cout << "Publishing size: 2 MB" << std::endl;
+        auto loaned = pub2mb_->borrow_loaned_message();
+        pub2mb_->publish(std::move(loaned));
+      } else if (size == "4mb" && pub4mb_) {
+        std::cout << "Publishing size: 4 MB" << std::endl;
+        auto loaned = pub4mb_->borrow_loaned_message();
+        pub4mb_->publish(std::move(loaned));
+      }
+    }
+  }
+
+  std::vector<std::string> sizes_;
+  int period_ms_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<benchmark_msgs::msg::Stamped10B>::SharedPtr pub10_;
+  rclcpp::Publisher<benchmark_msgs::msg::Stamped100KB>::SharedPtr pub100kb_;
+  rclcpp::Publisher<benchmark_msgs::msg::Stamped1MB>::SharedPtr pub1mb_;
+  rclcpp::Publisher<benchmark_msgs::msg::Stamped2MB>::SharedPtr pub2mb_;
+  rclcpp::Publisher<benchmark_msgs::msg::Stamped4MB>::SharedPtr pub4mb_;
+};
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  std::vector<std::string> sizes;
+  int period_ms = 100;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--sizes" && i + 1 < argc) {
+      for (int j = i + 1; j < argc && argv[j][0] != '-'; ++j) {
+        sizes.push_back(argv[j]);
+        i = j;
+      }
+    } else if (arg == "--period" && i + 1 < argc) {
+      period_ms = std::stoi(argv[++i]);
+    }
+  }
+  if (sizes.empty()) {
+    std::cerr << "Usage: benchmark_pub_fixed_size --sizes 10 100kb 1mb 2mb 4mb [--period <ms>]" << std::endl;
+    return 1;
+  }
+  auto node = std::make_shared<BenchmarkPubNode>(sizes, period_ms);
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/flatros2/examples/benchmark_sub.cpp
+++ b/flatros2/examples/benchmark_sub.cpp
@@ -1,0 +1,140 @@
+#include <chrono>
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <thread>
+#include <rclcpp/rclcpp.hpp>
+#include <flatros2/flatros2.hpp>
+#include <std_msgs/msg/header.hpp>
+#include <benchmark_msgs/msg/benchmark_data.hpp>
+
+using namespace flatros2;
+
+// Declare flat structure for builtin_interfaces::msg::Time
+DECLARE_FLAT_STRUCTURE(builtin_interfaces::msg::Time) {
+  FlatView<int32_t>& sec = this->template member_decl<int32_t>("sec");
+  FlatView<uint32_t>& nanosec = this->template member_decl<uint32_t>("nanosec");
+};
+
+// Declare flat structure for std_msgs::msg::Header
+DECLARE_FLAT_STRUCTURE(std_msgs::msg::Header) {
+  FlatView<builtin_interfaces::msg::Time>& stamp = this->template member_decl<builtin_interfaces::msg::Time>("stamp");
+};
+
+// Declare flat prototype for benchmark_msgs::msg::BenchmarkData
+DECLARE_FLAT_PROTOTYPE(benchmark_msgs::msg::BenchmarkData) {
+  FlatView<std_msgs::msg::Header>& header = this->template member_decl<std_msgs::msg::Header>("header");
+  FlatView<std::span<uint8_t>>& data = this->template member_decl<std::span<uint8_t>>("data");
+};
+
+
+// BenchmarkSubscriber node definition
+class BenchmarkSubscriber : public rclcpp::Node {
+public:
+  // Constructor: sets up log file and subscription
+  BenchmarkSubscriber()
+  : Node("benchmark_subscriber", rclcpp::NodeOptions().start_parameter_services(false)) {
+    // Open log file for latency results
+    logfile_.open("latency_log.csv");
+    logfile_ << "[START] Program started\n";
+    logfile_ << "size_bytes,latency_ms\n";
+    logfile_.flush();
+
+    // Create flat subscription to benchmark_topic
+    sub_ = create_flat_subscription<benchmark_msgs::msg::BenchmarkData>(
+      this, "benchmark_topic", 10,
+      [this](std::shared_ptr<Flat<benchmark_msgs::msg::BenchmarkData>> msg) {
+        // Callback: compute latency and log to file
+        auto now = this->get_clock()->now();
+        auto msg_time = rclcpp::Time(msg->header.stamp.sec, msg->header.stamp.nanosec, RCL_ROS_TIME);
+        double latency_ms = (now - msg_time).seconds() * 1e3;
+
+        auto data_span = static_cast<std::span<uint8_t>>(msg->data);
+        logfile_ << data_span.size() << "," << latency_ms << "\n";
+        logfile_.flush();
+        // RCLCPP_INFO(this->get_logger(), "Received message of size: %zu bytes, latency: %.2f ms", data_span.size(), latency_ms);
+      });
+  }
+
+  // Destructor: closes log file
+  ~BenchmarkSubscriber() {
+    if (logfile_.is_open()) {
+      logfile_ << "[END] Program exiting\n";
+      logfile_.flush();
+      logfile_.close();
+    }
+  }
+
+private:
+  // Log file for latency results
+  std::ofstream logfile_;
+  // Flat subscription handle
+  std::shared_ptr<FlatSubscription<benchmark_msgs::msg::BenchmarkData>> sub_;
+};
+
+// Main function: initializes ROS 2, spins node, and shuts down
+void print_help() {
+  const char* bold = "\033[1m";
+  const char* green = "\033[32m";
+  const char* yellow = "\033[33m";
+  const char* cyan = "\033[36m";
+  const char* reset = "\033[0m";
+  std::cout << bold << green << "Usage:" << reset << " benchmark_sub [--duration <seconds>] [--help]\n";
+  std::cout << yellow << "  --duration, -d <seconds>" << reset << "  Time to run before exiting (default: run until killed)\n";
+  std::cout << yellow << "  --help, -h           " << reset << "  Show this help message\n";
+  std::cout << "\n";
+  std::cout << cyan << "This program subscribes to messages and logs latency data to 'latency_log.csv'.\n" << reset;
+  std::cout << cyan << "You can analyze the latency data using the script 'analyze_latency.py'.\n" << reset;
+  std::cout << bold << "Instructions to run the subscriber:" << reset << std::endl;
+  std::cout << green << "  ./install/flatros2/lib/flatros2/benchmark_sub --duration 30" << reset << std::endl;
+  std::cout << "This will start the subscriber and log latency data to 'latency_log.csv'." << std::endl;
+  std::cout << "You can analyze the results with: " << yellow << "python3 /workspace/analyze_latency.py" << reset << std::endl;
+  std::cout << std::endl;
+  std::cout << bold << yellow << "Note:" << reset << " In another terminal, run the " << green << "publisher" << reset << " to send benchmark messages:" << std::endl;
+  std::cout << "  " << cyan << "python3 src/flatros2/examples/benchmark_pub.py --mode sweep" << reset << std::endl;
+  std::cout << "  (or use --mode duration)" << std::endl;
+}
+
+int main(int argc, char** argv) {
+  int duration_sec = -1;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--help" || arg == "-h") {
+      print_help();
+      return 0;
+    } else if ((arg == "--duration" || arg == "-d") && i + 1 < argc) {
+      duration_sec = std::stoi(argv[++i]);
+    }
+  }
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<BenchmarkSubscriber>();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  if (duration_sec > 0) {
+    auto start = std::chrono::steady_clock::now();
+    while (rclcpp::ok()) {
+      executor.spin_some();
+      auto now = std::chrono::steady_clock::now();
+      if (std::chrono::duration_cast<std::chrono::seconds>(now - start).count() >= duration_sec) {
+        std::cout << "Duration reached, shutting down." << std::endl;
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  } else {
+    executor.spin();
+  }
+  executor.remove_node(node);
+  rclcpp::shutdown();
+  // Print analysis instructions after finishing
+  const char* bold = "\033[1m";
+  const char* green = "\033[32m";
+  const char* yellow = "\033[33m";
+  const char* cyan = "\033[36m";
+  const char* reset = "\033[0m";
+  std::cout << std::endl;
+  std::cout << bold << green << "[Subscriber finished]" << reset << std::endl;
+  std::cout << cyan << "Latency data has been saved to 'latency_log.csv'." << reset << std::endl;
+  std::cout << "You can analyze the results with: " << yellow << "python3 /workspace/analyze_latency.py" << reset << std::endl;
+  return 0;
+}

--- a/flatros2/examples/benchmark_sub_fixed_size.cpp
+++ b/flatros2/examples/benchmark_sub_fixed_size.cpp
@@ -1,0 +1,171 @@
+#include <chrono>
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <thread>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/header.hpp>
+#include "benchmark_msgs/msg/stamped10_b.hpp"
+#include "benchmark_msgs/msg/stamped100_kb.hpp"
+#include "benchmark_msgs/msg/stamped1_mb.hpp"
+#include "benchmark_msgs/msg/stamped2_mb.hpp"
+#include "benchmark_msgs/msg/stamped4_mb.hpp"
+
+// Helper to extract timestamp from header
+rclcpp::Time get_stamp(const std_msgs::msg::Header& header) {
+  return rclcpp::Time(header.stamp.sec, header.stamp.nanosec, RCL_ROS_TIME);
+}
+
+
+// BenchmarkSubscriber node definition
+class BenchmarkSubscriber : public rclcpp::Node {
+public:
+  BenchmarkSubscriber(bool log_to_file = true, bool debug = false)
+    : Node("benchmark_subscriber_fixed_size", rclcpp::NodeOptions().start_parameter_services(false)),
+      log_to_file_(log_to_file), debug_(debug)
+  {
+    if (log_to_file_) {
+      logfile_.open("latency_log.csv");
+      logfile_ << "[START] Program started\n";
+      logfile_ << "size_bytes,latency_ms\n";
+      logfile_.flush();
+    }
+    // Subscribe to all fixed-size topics
+    sub10_ = this->create_subscription<benchmark_msgs::msg::Stamped10B>(
+      "benchmark/fixed/10", 10,
+      [this](const benchmark_msgs::msg::Stamped10B& msg) { handle_msg(msg); });
+    sub100kb_ = this->create_subscription<benchmark_msgs::msg::Stamped100KB>(
+      "benchmark/fixed/100kb", 10,
+      [this](const benchmark_msgs::msg::Stamped100KB& msg) { handle_msg(msg); });
+    sub1mb_ = this->create_subscription<benchmark_msgs::msg::Stamped1MB>(
+      "benchmark/fixed/1mb", 10,
+      [this](const benchmark_msgs::msg::Stamped1MB& msg) { handle_msg(msg); });
+    sub2mb_ = this->create_subscription<benchmark_msgs::msg::Stamped2MB>(
+      "benchmark/fixed/2mb", 10,
+      [this](const benchmark_msgs::msg::Stamped2MB& msg) { handle_msg(msg); });
+    sub4mb_ = this->create_subscription<benchmark_msgs::msg::Stamped4MB>(
+      "benchmark/fixed/4mb", 10,
+      [this](const benchmark_msgs::msg::Stamped4MB& msg) { handle_msg(msg); });
+  }
+
+  ~BenchmarkSubscriber() {
+    if (log_to_file_ && logfile_.is_open()) {
+      logfile_ << "[END] Program exiting\n";
+      logfile_.flush();
+      logfile_.close();
+    }
+  }
+
+private:
+  template<typename MsgT>
+  void handle_msg(const MsgT& msg) {
+    auto now = this->get_clock()->now();
+    auto msg_time = get_stamp(msg.header);
+    double latency_ms = (now - msg_time).seconds() * 1e3;
+    size_t size = msg.data.size();
+    if (log_to_file_ && logfile_.is_open()) {
+      logfile_ << size << "," << latency_ms << "\n";
+      logfile_.flush();
+    }
+    if (debug_) {
+      std::cout << "[DEBUG] Received message of size: " << size
+                << " bytes, latency: " << latency_ms << " ms" << std::endl;
+    }
+  }
+
+  std::ofstream logfile_;
+  rclcpp::Subscription<benchmark_msgs::msg::Stamped10B>::SharedPtr sub10_;
+  rclcpp::Subscription<benchmark_msgs::msg::Stamped100KB>::SharedPtr sub100kb_;
+  rclcpp::Subscription<benchmark_msgs::msg::Stamped1MB>::SharedPtr sub1mb_;
+  rclcpp::Subscription<benchmark_msgs::msg::Stamped2MB>::SharedPtr sub2mb_;
+  rclcpp::Subscription<benchmark_msgs::msg::Stamped4MB>::SharedPtr sub4mb_;
+  bool log_to_file_;
+  bool debug_;
+};
+
+void print_help() {
+  const char* bold = "\033[1m";
+  const char* green = "\033[32m";
+  const char* yellow = "\033[33m";
+  const char* cyan = "\033[36m";
+  const char* reset = "\033[0m";
+  std::cout << bold << green << "Usage:" << reset << " benchmark_sub_fixed_size [--duration <seconds>] [--log true|false] [--debug] [--help]\n";
+  std::cout << yellow << "  --duration, -d <seconds>" << reset << "  Time to run before exiting (default: run until killed)\n";
+  std::cout << yellow << "  --log true|false     " << reset << "  Enable or disable logging to file (default: true)\n";
+  std::cout << yellow << "  --debug              " << reset << "  Print each received message's size and latency to console\n";
+  std::cout << yellow << "  --help, -h           " << reset << "  Show this help message\n";
+  std::cout << "\n";
+  std::cout << cyan << "This program subscribes to fixed-size messages and logs latency data to 'latency_log.csv' (unless --log false).\n" << reset;
+  std::cout << cyan << "You can analyze the latency data using the script 'analyze_latency.py'.\n" << reset;
+  std::cout << bold << "Instructions to run the subscriber:" << reset << std::endl;
+  std::cout << green << "  ./install/flatros2/lib/flatros2/benchmark_sub_fixed_size --duration 30" << reset << std::endl;
+  std::cout << "This will start the subscriber and log latency data to 'latency_log.csv'." << std::endl;
+  std::cout << "You can analyze the results with: " << yellow << "python3 /workspace/analyze_latency.py" << reset << std::endl;
+  std::cout << std::endl;
+  std::cout << bold << yellow << "Note:" << reset << " In another terminal, run the " << green << "publisher" << reset << " to send benchmark messages:" << std::endl;
+  std::cout << "  " << cyan << "ros2 run flatros2 benchmark_pub_fixed_size --sizes 10 100kb 1mb 2mb 4mb --period 100" << reset << std::endl;
+}
+
+int main(int argc, char** argv) {
+  std::cout << "\033[1;31m[WARNING]\033[0m Ctrl+C does not work to stop this program.\n";
+  std::cout << "To kill all benchmark nodes and clean up shared memory, run:\n";
+  std::cout << "  pkill -9 -f 'benchmark_pub|benchmark_sub|ros2'; sudo rm -f /dev/shm/iox2_*; sudo rm -rf /tmp/iceoryx2\n";
+  std::cout << std::endl;
+  int duration_sec = -1;
+  bool log_to_file = true;
+  bool debug = false;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--help" || arg == "-h") {
+      print_help();
+      return 0;
+    } else if ((arg == "--duration" || arg == "-d") && i + 1 < argc) {
+      duration_sec = std::stoi(argv[++i]);
+    } else if (arg == "--log" && i + 1 < argc) {
+      std::string val = argv[++i];
+      if (val == "false" || val == "0") log_to_file = false;
+      else log_to_file = true;
+    } else if (arg == "--debug") {
+      debug = true;
+    }
+  }
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<BenchmarkSubscriber>(log_to_file, debug);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  if (duration_sec > 0) {
+    std::atomic<bool> done{false};
+    std::thread spin_thread([&]() {
+      executor.spin();
+      done = true;
+    });
+    auto start = std::chrono::steady_clock::now();
+    while (!done) {
+      auto now = std::chrono::steady_clock::now();
+      if (std::chrono::duration_cast<std::chrono::seconds>(now - start).count() >= duration_sec) {
+        std::cout << "Duration reached, shutting down." << std::endl;
+        executor.cancel();
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    spin_thread.join();
+  } else {
+    executor.spin();
+  }
+  executor.remove_node(node);
+  rclcpp::shutdown();
+  // Print analysis instructions after finishing
+  const char* bold = "\033[1m";
+  const char* green = "\033[32m";
+  const char* yellow = "\033[33m";
+  const char* cyan = "\033[36m";
+  const char* reset = "\033[0m";
+  std::cout << std::endl;
+  std::cout << bold << green << "[Subscriber finished]" << reset << std::endl;
+  if (log_to_file) {
+    std::cout << cyan << "Latency data has been saved to 'latency_log.csv'." << reset << std::endl;
+    std::cout << "You can analyze the results with: " << yellow << "python3 /workspace/analyze_latency.py" << reset << std::endl;
+  }
+  return 0;
+}

--- a/flatros2/flatros2/__init__.py
+++ b/flatros2/flatros2/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .message import Flat

--- a/flatros2/package.xml
+++ b/flatros2/package.xml
@@ -21,6 +21,7 @@
   <depend>cv_bridge</depend>
   <depend>rcl</depend>
   <depend>rclcpp</depend>
+  <depend>benchmark_msgs</depend>
   <depend>rmw</depend>
   <depend>rosidl_runtime_c</depend>
   <depend>rosidl_runtime_cpp</depend>

--- a/iceoryx.repos
+++ b/iceoryx.repos
@@ -1,4 +1,5 @@
 repositories:
+  # Iceoryx-related
   eclipse-iceoryx/iceoryx:
     type: git
     url: https://github.com/eclipse-iceoryx/iceoryx.git
@@ -9,5 +10,15 @@ repositories:
     version: v0.5.0
   rmw_iceoryx2_cxx:
     type: git
-    url: https://github.com/Ekumen-OS/rmw_iceoryx2.git 
+    url: https://github.com/Ekumen-OS/rmw_iceoryx2.git
     version: flatros2-compatible
+
+  # Needed to build flatros
+  common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: jazzy
+  test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: jazzy

--- a/ros2-core.repos
+++ b/ros2-core.repos
@@ -1,0 +1,26 @@
+repositories:
+  # ROS 2 Jazzy repos to modify the source code (optional!)
+  rcl:
+    type: git
+    url: https://github.com/ros2/rcl.git
+    version: jazzy
+  rclcpp:
+    type: git
+    url: https://github.com/ros2/rclcpp.git
+    version: jazzy
+  rclpy:
+    type: git
+    url: https://github.com/ros2/rclpy.git
+    version: jazzy
+  rcutils:
+    type: git
+    url: https://github.com/ros2/rcutils.git
+    version: jazzy
+  rmw:
+    type: git
+    url: https://github.com/ros2/rmw.git
+    version: jazzy
+  rmw_implementation:
+    type: git
+    url: https://github.com/ros2/rmw_implementation.git
+    version: jazzy


### PR DESCRIPTION
- Added new ROS 2 package `benchmark_msgs` with `BenchmarkData.msg` (std_msgs/Header + uint8[]).
- Implemented `benchmark_pub.py`: Python FlatPublisher to publish configurable size messages (sweep/duration modes).
- Implemented `benchmark_sub.cpp`: C++ FlatSubscriber that logs latency per message to `latency_log.csv`.
- Added `analyze_latency.py` script to plot and summarize latency results.
- Updated `flatros2/examples/CMakeLists.txt` to build/install new benchmark nodes.
- Updated `flatros2/package.xml` and `CMakeLists.txt` to depend on `benchmark_msgs`.
- Exposed `Flat` symbol in Python init for convenience.
- Significantly expanded README with:
  - Workspace layout/setup instructions
  - Troubleshooting tips
  - How to run the benchmark pub/sub nodes
  - How to analyze results with the new script
- Updated `iceoryx.repos` to include additional Jazzy dependencies: `common_interfaces`, `test_interface_files`.